### PR TITLE
Virginia Copay Fix

### DIFF
--- a/functions/CCDF.R
+++ b/functions/CCDF.R
@@ -5748,7 +5748,7 @@ function.CCDFcopay<-function(data
     
     temp$totcopay[temp$ruleYear<2023]<-temp$income[temp$ruleYear<2023]*temp$FTcopay[temp$ruleYear<2023]
     
-    temp$totcopay[temp$ruleYear>=2023]<-temp$income[temp$ruleYear>=2023]*12
+    temp$totcopay[temp$ruleYear>=2023]<-temp$FTcopay[temp$ruleYear>=2023]*12
     
     temp$totcopay<-rowMins(cbind(temp$totcopay,temp$netexp.childcare))
     


### PR DESCRIPTION
Corrected Virginia totcopay calculation was using income instead of FTcopay