### PR TITLE
NY CCDF Fix

### DIFF
--- a/functions/CCDF.R
+++ b/functions/CCDF.R
@@ -4225,7 +4225,7 @@ function.CCDFcopay<-function(data
     
     # Apply asset test
     subset<-temp$totalassets > temp$AssetTest
-    temp$FTcopay[subset]<-NA_real_
+    temp$weeklyCopay[subset]<-NA_real_
     
     #----------------------------------
     # Step 2: Calculate total copays


### PR DESCRIPTION
New York totcopay is calculated using weeklyCopay variable instead of FTcopay variable